### PR TITLE
Add links to chartkick, iruby-chartkick and jupyter_on_rails

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -184,6 +184,10 @@ Comprehensive tools for Data Visualization.
 - https://github.com/masa16/ruby-mathgl
 - [numo-gnuplot](https://github.com/ruby-numo/numo-gnuplot) &mdash;
   gnuplot interface for the Numo package.
+- [chartkick](https://github.com/ankane/chartkick) &mdash;
+  Create beautiful JavaScript charts with one line of Ruby.
+- [iruby-chartkick](https://github.com/Absolventa/iruby-chartkick) &mdash;
+  Use [chartkick](https://github.com/ankane/chartkick) within IRuby-backed jupyter notebooks
 
 ## Interactive Computing
 
@@ -191,6 +195,9 @@ Comprehensive tools for Data Visualization.
   Ruby kernel for [Jupyter](https://jupyter.org/).
 - [iruby-rails](https://github.com/mrkn/iruby-rails) &mdash;
   Integration library for IRuby and Rails.
+- [jupyter_on_rails](https://github.com/Yuki-Inoue/jupyter_on_rails/) &mdash;
+  Another integration library for IRuby and Rails.
+
 
 ## Input and Output
 


### PR DESCRIPTION
This PR adds links to the the tools I currently use a lot: 
* [Yuki-Inoue/jupyter_on_rails](https://github.com/Yuki-Inoue/jupyter_on_rails/)
* [ankane/chartkick](https://github.com/ankane/chartkick)
* [Absolventa/iruby-chartkick](https://github.com/Absolventa/iruby-chartkick)

Since I'm not the owner of the first two, i've only added the label `rubydatascience` to the latter repository :) 

- [x] I've accepted the terms of the `CC0` License;
- [x] I've added the topic `rubydatascience` to the contributed repository if appropriate.
